### PR TITLE
[READY] Browser integration

### DIFF
--- a/config/images.yaml
+++ b/config/images.yaml
@@ -1,14 +1,14 @@
 'spurious-sqs':
   :image: 'spurious/sqs'
-  :hostname: 'spurious.sqs.local'
+  :hostname: 'sqs.spurious.localhost'
 
 'spurious-s3':
   :image: 'spurious/s3'
-  :hostname: 'spurious.s3.local'
+  :hostname: 's3.spurious.localhost'
 
 'spurious-dynamo':
   :image: 'spurious/dynamodb'
-  :hostname: 'spurious.dynamodb.local'
+  :hostname: 'dynamodb.spurious.localhost'
 
 'spurious-memcached':
   :image: 'smaj/memcached'
@@ -31,7 +31,7 @@
 'spurious-browser':
   :image: 'spurious/browser'
   :link:
-    - 'spurious-dynamo:spurious.dynamodb.local'
-    - 'spurious-sqs:spurious.sqs.local'
-    - 'spurious-s3:spurious.s3.local'
-  :hostname: 'spurious.browser.local'
+    - 'spurious-dynamo:dynamodb.spurious.localhost'
+    - 'spurious-sqs:sqs.spurious.localhost'
+    - 'spurious-s3:s3.spurious.localhost'
+  :hostname: 'browser.spurious.localhost'

--- a/config/images.yaml
+++ b/config/images.yaml
@@ -1,11 +1,14 @@
 'spurious-sqs':
   :image: 'smaj/spurious-sqs'
+  :hostname: 'spurious.sqs.local'
 
 'spurious-s3':
   :image: 'smaj/spurious-s3'
+  :hostname: 'spurious.s3.local'
 
 'spurious-dynamo':
   :image: 'smaj/spurious-dynamo'
+  :hostname: 'spurious.dynamodb.local'
 
 'spurious-memcached':
   :image: 'smaj/memcached'
@@ -24,3 +27,11 @@
     :delete: true
   :link:
     - 'spurious-memcached:memcached01'
+
+'spurious-browser':
+  :image: 'smaj/spurious-browser'
+  :link:
+    - 'spurious-dynamo:spurious.dynamodb.local'
+    - 'spurious-sqs:spurious.sqs.local'
+    - 'spurious-s3:spurious.s3.local'
+  :hostname: 'spurious.browser.local'

--- a/config/images.yaml
+++ b/config/images.yaml
@@ -1,27 +1,27 @@
 'spurious-sqs':
-  :image: 'smaj/spurious-sqs'
+  :image: 'spurious/sqs'
   :hostname: 'spurious.sqs.local'
 
 'spurious-s3':
-  :image: 'smaj/spurious-s3'
+  :image: 'spurious/s3'
   :hostname: 'spurious.s3.local'
 
 'spurious-dynamo':
-  :image: 'smaj/spurious-dynamo'
+  :image: 'spurious/dynamodb'
   :hostname: 'spurious.dynamodb.local'
 
 'spurious-memcached':
   :image: 'smaj/memcached'
 
 'spurious-elasticache':
-  :image: 'smaj/fake-elasticache'
+  :image: 'spurious/elasticache'
   :link:
     - 'spurious-memcached:memcached01'
   :env:
     FAKEELASTICACHE_DEFAULT_HOST: '127.0.0.1'
 
 'spurious-elasticache-docker':
-  :image: 'smaj/fake-elasticache'
+  :image: 'spurious/elasticache'
   :ignore:
     :create: true
     :delete: true
@@ -29,7 +29,7 @@
     - 'spurious-memcached:memcached01'
 
 'spurious-browser':
-  :image: 'smaj/spurious-browser'
+  :image: 'spurious/browser'
   :link:
     - 'spurious-dynamo:spurious.dynamodb.local'
     - 'spurious-sqs:spurious.sqs.local'

--- a/lib/spurious/server/state/init.rb
+++ b/lib/spurious/server/state/init.rb
@@ -64,7 +64,7 @@ module Spurious
         def operation_complete(complete)
           if complete
             send("#{app_config.length} containers successfully initialized", :info, false, :green)
-            send("Please add the following to your /etc/hosts file:\n\n#{docker_host} spurious.sqs.local spurious.s3.local spurious.dynamodb.local spurious.browser.local\n", :info, true, :blue)
+            send("Please add the following to your /etc/hosts file:\n\n#{docker_host} sqs.spurious.localhost s3.spurious.localhost dynamodb.spurious.localhost browser.spurious.localhost\n", :info, true, :blue)
           end
         end
 

--- a/lib/spurious/server/state/init.rb
+++ b/lib/spurious/server/state/init.rb
@@ -33,7 +33,7 @@ module Spurious
             end
             container_cmd = []
 
-            if meta[:image] == 'smaj/spurious-s3'
+            if meta[:image] == 'spurious/s3'
               container_cmd = ['-h', meta[:hostname]]
             end
 

--- a/lib/spurious/server/state/init.rb
+++ b/lib/spurious/server/state/init.rb
@@ -34,7 +34,7 @@ module Spurious
             container_cmd = []
 
             if meta[:image] == 'smaj/spurious-s3'
-              container_cmd = ['-h', docker_host]
+              container_cmd = ['-h', meta[:hostname]]
             end
 
             create_container = Proc.new do
@@ -62,7 +62,10 @@ module Spurious
         end
 
         def operation_complete(complete)
-          send("6 containers successfully initialized", :info, true, :green) if complete
+          if complete
+            send("#{app_config.length} containers successfully initialized", :info, false, :green)
+            send("Please add the following to your /etc/hosts file:\n\n#{docker_host} spurious.sqs.local spurious.s3.local spurious.dynamodb.local spurious.browser.local\n", :info, true, :blue)
+          end
         end
 
       end

--- a/lib/spurious/server/state/init.rb
+++ b/lib/spurious/server/state/init.rb
@@ -34,7 +34,7 @@ module Spurious
             container_cmd = []
 
             if meta[:image] == 'spurious/s3'
-              container_cmd = ['-h', meta[:hostname]]
+              container_cmd = ['-H', meta[:hostname]]
             end
 
             create_container = Proc.new do

--- a/lib/spurious/server/state/ports.rb
+++ b/lib/spurious/server/state/ports.rb
@@ -17,15 +17,17 @@ module Spurious
         def execute!
           ports = {}
           spurious_containers.peach do |container|
+            a_config = app_config[container.json['Name'].gsub('/', '')]
             config = container_config(container.json["Name"])
             ports[sanitize(container.json["Name"])] = []
 
             if !container.json["NetworkSettings"]["Ports"].nil? then
+              host = a_config
 
               container.json["NetworkSettings"]["Ports"].each do |guest, mapping|
                 mapping.each do |map|
                   ports[sanitize(container.json["Name"])] << {
-                    :Host       => docker_host_ip,
+                    :Host       => a_config.fetch(:hostname, docker_host_ip),
                     :HostPort   => map["HostPort"]
                  }
                 end

--- a/lib/spurious/server/state/start.rb
+++ b/lib/spurious/server/state/start.rb
@@ -35,8 +35,9 @@ module Spurious
               if container.json["Name"] == '/spurious-sqs' then
                 port_setup = Proc.new do
                   begin
+                    container_config = app_config['spurious-sqs']
                     port = container.json["NetworkSettings"]["Ports"]['4568/tcp'].first['HostPort']
-                    Net::HTTP.get(URI("http://#{docker_host_ip}:#{port}/host-details?host=#{docker_host_ip}&port=#{port}"))
+                    Net::HTTP.get(URI("http://#{docker_host_ip}:#{port}/host-details?host=#{container_config[:hostname]}&port=#{port}"))
                   rescue StandardError => e
                   end
                 end

--- a/spurious-server.gemspec
+++ b/spurious-server.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "eventmachine"
   spec.add_runtime_dependency "em-synchrony"
-  spec.add_runtime_dependency "docker-api"
+  spec.add_runtime_dependency "docker-api", "1.13.6"
   spec.add_runtime_dependency "daemons"
   spec.add_runtime_dependency "peach"
 


### PR DESCRIPTION
This PR adds [spurious-browser](https://www.github.com/stevenjack/spurious-browser) to the services started when running `spurious start`.

This now means that you can browse the local services with a GUI.

To access the browser, run `spurious ports` and find the link for `spurious-browser`.