### PR TITLE
[READY] Removes docker-api restriction

### DIFF
--- a/spurious-server.gemspec
+++ b/spurious-server.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "eventmachine"
   spec.add_runtime_dependency "em-synchrony"
-  spec.add_runtime_dependency "docker-api", "1.13.6"
+  spec.add_runtime_dependency "docker-api"
   spec.add_runtime_dependency "daemons"
   spec.add_runtime_dependency "peach"
 


### PR DESCRIPTION
Now the bugs in the `docker-api` gem have been fixed, this PR removes the version lock.